### PR TITLE
Simplify build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+
+all: CMakeLists.txt
+	mkdir -p build; \
+	cd build; \
+	cmake ..; \
+	make;
+
+clean:
+	rm -rf build
+	rm bake

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ FLEX_TARGET(SCANNER ${CMAKE_CURRENT_SOURCE_DIR}/cool.l ${CMAKE_CURRENT_BINARY_DI
 #find_package(GTest REQUIRED)
 #include_directories(${GTEST_INCLUDE_DIRS})
 
+set(EXECUTABLE_OUTPUT_PATH ../..)
 add_executable( bake
     driver.cpp
     ${FLEX_SCANNER_OUTPUTS}

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -12,7 +12,7 @@ from subprocess import check_output, STDOUT, CalledProcessError
 import difflib
 import codecs
 
-BAKE = "../build/src/bake"
+BAKE = "../bake"
 CL_TEST_DIR = "lexer_tests/" # Directory that contains the .cl files to be tested
 OUTPUT = "lexer_output/" # Where to put the lexer files produced by the official Cool interpreter.
 VERBOSE = "v" in sys.argv


### PR DESCRIPTION
Moved the features of cmake_script.sh into a makefile. This allows us to easily have a make clean command that deletes the correct  build directory.

Also made it so the executable is placed in the main bake directory.
