### PR TITLE
Strdup versus new string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 set(CMAKE_CXX_COMPILER "/usr/bin/clang++")
-add_compile_options(-std=c++11 -g -Wall)
+add_compile_options(-std=c++11 -g -Wall -Wno-deprecated-register)
 
 project(bake)
 

--- a/include/ast/terminals.h
+++ b/include/ast/terminals.h
@@ -2,8 +2,7 @@
 #ifndef __TERMINALS__
 #define __TERMINALS__
 
-#include <string>
-using namespace std;
+#include <string.h>
 #include "node.h"
 
 namespace bake_ast {
@@ -36,10 +35,10 @@ namespace bake_ast {
     StringVal(const char* val);
     virtual ~StringVal();
     void accept(bake_ast::Visitor* v) { v->visit(this); }
-    string* getValue() { return val; }
+    char* getValue() { return val; }
 
   private:
-    string* val;
+    char* val;
   };
 
   /**
@@ -66,10 +65,10 @@ namespace bake_ast {
     Id(const char* name);
     virtual ~Id();
     void accept(bake_ast::Visitor* v) { v->visit(this); }
-    string* getName() { return this->name; }
+    char* getName() { return this->name; }
 
   private:
-    string* name;
+    char* name;
   };
 
   /**
@@ -80,10 +79,10 @@ namespace bake_ast {
     Type(const char* name);
     virtual ~Type();
     void accept(bake_ast::Visitor* v) { v->visit(this); }
-    string* getName() { return this->name; }
+    char* getName() { return this->name; }
 
   private:
-    string* name;
+    char* name;
   };
 }
 

--- a/src/ast/terminals.cpp
+++ b/src/ast/terminals.cpp
@@ -11,7 +11,7 @@ using namespace bake_ast;
  * This was done in the interest of simplifying memory management.
  */
 StringVal::StringVal(const char* val) : Leaf(STRINGVAL) {
-  this->val = new string(val);
+  this->val = strdup(val);
 }
 
 StringVal::~StringVal() {
@@ -21,7 +21,7 @@ StringVal::~StringVal() {
 /*********** Id methods ***********/
 
 Id::Id(const char* name) : Leaf(IDVAL) {
-  this->name = new string(name);
+  this->name = strdup(name);
 }
 
 Id::~Id() {
@@ -31,7 +31,7 @@ Id::~Id() {
 /*********** Type methods ***********/
 
 Type::Type(const char* name) : Leaf(TYPEVAL) {
-  this->name = new string(name);
+  this->name = strdup(name);
 }
 
 Type::~Type() {


### PR DESCRIPTION
Changed string copying from calling the string constructor to calling C's strdup function.
